### PR TITLE
Disable inline HTML check (MD033)

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -16,6 +16,10 @@
 # report those cases.
 "MD013": false
 
+# I am intentionally using the `details` and `summary` elements to "window
+# shade" verbose details.
+"MD033": false
+
 # Don't complain if sub-heading names are duplicated since this is a common
 # practice in CHANGELOG.md (e.g., "Fixed").
 "MD024":


### PR DESCRIPTION
I'm intentionally using inline HTML elements `details` and
`summary` in an effort to hide verbose details by default.